### PR TITLE
Add check file or directory on StaticFileIntercepter.

### DIFF
--- a/src/main/kotlin/org/wasabi/interceptors/StaticFileInterceptor.kt
+++ b/src/main/kotlin/org/wasabi/interceptors/StaticFileInterceptor.kt
@@ -13,7 +13,7 @@ public class StaticFileInterceptor(val folder: String): Interceptor() {
         if (request.method == HttpMethod.GET) {
             val fullPath = "${folder}${request.uri}"
             val file = File(fullPath)
-            if (file.exists()) {
+            if (file.exists() && file.isFile()) {
                 response.streamFile(fullPath)
             } else {
                 next()

--- a/test/main/kotlin/org/wasabi/test/StaticFileInterceptorSpecs.kt
+++ b/test/main/kotlin/org/wasabi/test/StaticFileInterceptorSpecs.kt
@@ -40,5 +40,11 @@ public class StaticFileInterceptorSpecs: TestServerContext() {
         assertEquals(404, response.statusCode)
     }
 
+    spec fun requesting_an_existing_static_direcotry_should_go_to_next() {
+        TestServer.appServer.serveStaticFilesFromFolder("testData${File.separatorChar}public")
+        TestServer.loadDefaultRoutes()
+        val response = get("http://localhost:${TestServer.definedPort}/", hashMapOf())
+        assertEquals("Root", response.body)
+    }
 
 }


### PR DESCRIPTION
```
fun main(args: Array<String>) {
    val server = AppServer()
    server.serveStaticFilesFromFolder("public")

    // 404 not found
    // because intercept by StaticFileInterceptor.
    // "public/" is exists. But this is not a file.
    // response.streamFile("public/") set status 404 in StaticFileInterceptor
    server.get("/", { response.send("Root") })
    server.start()
}
```