### PR TITLE
The tools default gradle script now points to correct ServerKt class.

### DIFF
--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -51,7 +51,7 @@ task createGradle(dependsOn: setup) << {
         def gradleFile = new File(project.dir+'/build.gradle')
        
          
-        def mainClass = project.package + '.' + getDomain(project.package) + 'Package'
+        def mainClass = project.package + '.' + 'ServerKt'
         gradleFile.append("""\
 buildscript {
     project.ext.kotlin_version = '0.1-SNAPSHOT'


### PR DESCRIPTION
Wasn't able to run wasabi because it complained about some missing package. Possibly related to how Kotlin generates classes now.