### PR TITLE
upgraded kobalt, removed rxjava, fixed slf4j-simple dep

### DIFF
--- a/kobalt/src/Build.kt
+++ b/kobalt/src/Build.kt
@@ -1,8 +1,10 @@
 import com.beust.kobalt.*
 import com.beust.kobalt.plugin.packaging.assemble
 import com.beust.kobalt.plugin.kotlin.*
+//import com.beust.kobalt.plugin.dokka.*
 
-val kotlin_version = "0.1-SNAPSHOT"
+val kotlin_version = "1.0.0-beta-4583"
+val repos = repos("http://repository.jetbrains.com/all", "https://oss.sonatype.org/content/repositories/snapshots/")
 
 val p = kotlinProject {
 
@@ -11,20 +13,9 @@ val p = kotlinProject {
     artifactId = name
     version = "0.1"
 
-    val repos = repos("http://oss.sonatype.org/content/repositories/snapshots")
-
-    sourceDirectories {
-        path("src/main/kotlin")
-    }
-
-    sourceDirectoriesTest {
-        path("test/main/kotlin")
-    }
-
     dependencies {
         compile("org.jetbrains.kotlin:kotlin-stdlib:" + kotlin_version)
         compile("org.jetbrains.kotlin:kotlin-reflect:" + kotlin_version)
-
         compile("com.fasterxml.jackson.core:jackson-core:2.6.4")
         compile("com.fasterxml.jackson.core:jackson-databind:2.6.4")
         compile("com.fasterxml.jackson.core:jackson-annotations:2.6.4")
@@ -34,14 +25,13 @@ val p = kotlinProject {
         compile("io.netty:netty-all:4.0.31.Final")
         compile("commons-codec:commons-codec:1.6")
         compile("commons-logging:commons-logging:1.1.1")
-        compile("com.netflix.rxjava:rxjava-core:0.20.0-RC4")
         compile("org.slf4j:slf4j-api:1.7.5")
-        compile("org.slf4j:slf4j-simple:1.7.5")
         compile("joda-time:joda-time:2.3")
     }
 
     dependenciesTest {
         compile("junit:junit:4.9")
+        compile("org.slf4j:slf4j-simple:1.7.5")
         compile("org.mockito:mockito-all:1.9.5")
         compile("org.apache.httpcomponents:httpcore:4.3.3")
         compile("org.apache.httpcomponents:httpclient:4.5.1")
@@ -49,6 +39,16 @@ val p = kotlinProject {
 
     assemble {
         jar {
+            fatJar=true
+            name = "wasabi-fat-" + version + ".jar"
+        }
+        mavenJars{
         }
     }
+
+/*
+    dokka {
+        outputFormat = "markdown"
+    }
+*/
 }

--- a/kobalt/wrapper/kobalt-wrapper.properties
+++ b/kobalt/wrapper/kobalt-wrapper.properties
@@ -1,1 +1,1 @@
-kobalt.version=0.341
+kobalt.version=0.393


### PR DESCRIPTION
I didn't see where rxjava is being used in the code, so i removed the dep

I made the slf4j-simple a test dependency only

The build also produces a fat-jar for those who would like to build the latest wasabi against a known version of kotlin (beta 4)