### PR TITLE
Fixed issue with AutoOptionsInterceptor

### DIFF
--- a/src/main/kotlin/org/wasabi/interceptors/AutoOptionsInterceptor.kt
+++ b/src/main/kotlin/org/wasabi/interceptors/AutoOptionsInterceptor.kt
@@ -7,17 +7,23 @@ import io.netty.handler.codec.http.HttpMethod
 import java.util.ArrayList
 import org.wasabi.routing.Route
 import org.wasabi.http.StatusCodes
+import org.wasabi.routing.PatternAndVerbMatchingRouteLocator
 
 public class AutoOptionsInterceptor(val routes: ArrayList<Route>): Interceptor() {
     override fun intercept(request: Request, response: Response): Boolean {
         var executeNext = false
         if (request.method == HttpMethod.OPTIONS) {
-            val methods = routes.filter {
-                it.path == request.path
-            }.map {
-                it.method
-            }
-            response.addRawHeader("Allow", methods.joinToString(", "))
+            val routeLocator = PatternAndVerbMatchingRouteLocator(routes)
+            val allowedMethods = routes
+                .filter { routeLocator.compareRouteSegments(it, request.path) }
+                .map { it.method }
+                .toTypedArray()
+
+
+            response.setAllowedMethods(allowedMethods)
+            response.addRawHeader("Access-Control-Allow-Origin", "*")
+            response.addRawHeader("Access-Control-Allow-Methods", allowedMethods.joinToString(", "))
+            response.addRawHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
             response.setStatus(StatusCodes.OK)
         } else {
             executeNext = true


### PR DESCRIPTION
Two issues solved here
1) If I have defined routes with route parameters (let's say, GET /todos/:id/), AutoOptionsInterceptor does not match it, because it compares strings of current request's path with route's path. Result gets this: '/todos/:id/' == '/todos/16', so it always will be false
2) Added additional response headers for browser to have full CORS support for other methods , such as PUT, DELETE, etc.