### PR TITLE
NPE fixed in SessionManagementInterceptor

### DIFF
--- a/src/main/kotlin/org/wasabi/interceptors/SessionManagementInterceptor.kt
+++ b/src/main/kotlin/org/wasabi/interceptors/SessionManagementInterceptor.kt
@@ -19,7 +19,7 @@ public class SessionManagementInterceptor(val cookieKey: String = "_sessionID", 
         val x = request.cookies[cookieKey]
         if (x != null && x.value != "") {
             // If we have a session bump the expiration time to keep it active
-            request.session = loadSession(request.session!!.id)
+            request.session = loadSession(x)
             request.session!!.extendSession();
         } else {
             request.session = Session(generateSessionID())


### PR DESCRIPTION
It was trying to use a session id from the request, not from the cookie