### PR TITLE
Fixes for auto-options and deserializers

### DIFF
--- a/src/main/kotlin/org/wasabi/deserializers/Deserializer.kt
+++ b/src/main/kotlin/org/wasabi/deserializers/Deserializer.kt
@@ -5,7 +5,18 @@ import java.util.HashMap
 abstract public class Deserializer(vararg val mediaTypes: String) {
     open fun canDeserialize(mediaType: String): Boolean {
         for (supportedMediaType in mediaTypes) {
-            if (mediaType.matches(supportedMediaType.toRegex())) {
+            /**
+             * Content type may provide a charset:
+             * application/x-www-form-urlencoded; charset=utf-8
+             * (we SHOULD match this)
+             *
+             * Or have a custom suffix:
+             * application/x-www-form-urlencoded-v2
+             * (we SHOULDN'T match this)
+             *
+             * And remember that HTTP headers are case-insensitive.
+             */
+            if (mediaType.matches("$supportedMediaType(;.*)?".toRegex(RegexOption.IGNORE_CASE))) {
                 return true
             }
         }

--- a/src/main/kotlin/org/wasabi/deserializers/JsonDeserializer.kt
+++ b/src/main/kotlin/org/wasabi/deserializers/JsonDeserializer.kt
@@ -4,7 +4,7 @@ import java.util.HashMap
 import com.fasterxml.jackson.databind.ObjectMapper
 
 
-public class JsonDeserializer: Deserializer("application/json", "application/json;\\s*charset=\\w*\\W*\\w*") {
+public class JsonDeserializer: Deserializer("application/json") {
     // TODO: This is temp as it doesn't correctly handle x.y properties
 
     @Suppress("UNCHECKED_CAST")

--- a/src/main/kotlin/org/wasabi/interceptors/AutoOptionsInterceptor.kt
+++ b/src/main/kotlin/org/wasabi/interceptors/AutoOptionsInterceptor.kt
@@ -31,5 +31,5 @@ public fun AppServer.enableAutoOptions() {
     intercept(AutoOptionsInterceptor(routes))
 }
 public fun AppServer.disableAutoOptions() {
-    this.interceptors.remove(AutoOptionsInterceptor(routes) as Any)
+    this.interceptors.removeAll { it.interceptor is AutoOptionsInterceptor }
 }

--- a/test/main/kotlin/org/wasabi/test/AutoOptionsInterceptorSpecs.kt
+++ b/test/main/kotlin/org/wasabi/test/AutoOptionsInterceptorSpecs.kt
@@ -31,4 +31,15 @@ public class AutoOptionsInterceptorSpecs : TestServerContext() {
 
     }
 
+    @spec fun testing_auto_options_shutdown () {
+        TestServer.appServer.enableAutoOptions()
+
+        assertEquals(1, TestServer.appServer.interceptors.count { it.interceptor is AutoOptionsInterceptor })
+
+        TestServer.appServer.disableAutoOptions()
+
+        assertEquals(0, TestServer.appServer.interceptors.count { it.interceptor is AutoOptionsInterceptor })
+
+    }
+
 }

--- a/test/main/kotlin/org/wasabi/test/SerializerSpecs.kt
+++ b/test/main/kotlin/org/wasabi/test/SerializerSpecs.kt
@@ -1,5 +1,7 @@
 package org.wasabi.test
 
+import org.wasabi.deserializers.JsonDeserializer
+import org.wasabi.deserializers.MultiPartFormDataDeserializer
 import org.junit.Test as spec
 import org.wasabi.serializers.JsonSerializer
 import org.wasabi.serializers.XmlSerializer
@@ -21,5 +23,17 @@ public class SerializerSpecs {
 
     }
 
+    @spec fun canDeserialize_should_return_true_when_given_a_media_type_that_deserializer_can_process() {
+
+        val jsonDeserializer = JsonDeserializer()
+        val mpDeserializer = MultiPartFormDataDeserializer()
+
+        assertEquals(true, jsonDeserializer.canDeserialize("application/json"))
+        assertEquals(false, jsonDeserializer.canDeserialize("application/json-v2"))
+        assertEquals(true, mpDeserializer.canDeserialize("application/x-www-form-urlencoded"))
+        assertEquals(true, mpDeserializer.canDeserialize("application/X-WWW-Form-Urlencoded; charset=ISO-8859-1"))
+        assertEquals(false, mpDeserializer.canDeserialize("application/x-www-form-urlencoded-v2; charset=utf-8"))
+
+    }
+
 }
-    


### PR DESCRIPTION
Deserializers didn't match cases when, for example, a charset was provided:
`application/x-www-form-urlencoded; charset=utf-8`
In particular, OkHttp sends `POST` using such content-type.

Also `disableAutoOptions()` was broken.