### PR TITLE
Add support for default file in StaticFileInterceptor

### DIFF
--- a/src/main/kotlin/org/wasabi/interceptors/StaticFileInterceptor.kt
+++ b/src/main/kotlin/org/wasabi/interceptors/StaticFileInterceptor.kt
@@ -10,12 +10,13 @@ import java.io.File
 public class StaticFileInterceptor(val folder: String, val useDefaultFile: Boolean = false, val defaultFile: String = "index.html") : Interceptor() {
     override fun intercept(request: Request, response: Response): Boolean {
         var executeNext = false
+
         if (request.method == HttpMethod.GET) {
             val fullPath = "${folder}${request.uri}"
             val file = File(fullPath)
             when {
                 file.exists() && file.isFile() -> response.setFileResponseHeaders(fullPath)
-                file.exists() && file.isDirectory() -> response.setFileResponseHeaders("${fullPath}/${defaultFile}")
+                file.exists() && file.isDirectory() && useDefaultFile -> response.setFileResponseHeaders("${fullPath}/${defaultFile}")
                 else -> executeNext = true
             }
         } else {

--- a/src/main/kotlin/org/wasabi/interceptors/StaticFileInterceptor.kt
+++ b/src/main/kotlin/org/wasabi/interceptors/StaticFileInterceptor.kt
@@ -1,23 +1,22 @@
 package org.wasabi.interceptors
 
+import io.netty.handler.codec.http.HttpMethod
+import org.wasabi.app.AppServer
 import org.wasabi.protocol.http.Request
 import org.wasabi.protocol.http.Response
-import org.wasabi.app.AppServer
-import org.wasabi.routing.InterceptOn
 import java.io.File
-import io.netty.handler.codec.http.HttpMethod
 
 
-public class StaticFileInterceptor(val folder: String): Interceptor() {
+public class StaticFileInterceptor(val folder: String, val useDefaultFile: Boolean = false, val defaultFile: String = "index.html") : Interceptor() {
     override fun intercept(request: Request, response: Response): Boolean {
         var executeNext = false
         if (request.method == HttpMethod.GET) {
             val fullPath = "${folder}${request.uri}"
             val file = File(fullPath)
-            if (file.exists() && file.isFile()) {
-                response.setFileResponseHeaders(fullPath)
-            } else {
-                executeNext = true
+            when {
+                file.exists() && file.isFile() -> response.setFileResponseHeaders(fullPath)
+                file.exists() && file.isDirectory() -> response.setFileResponseHeaders("${fullPath}/${defaultFile}")
+                else -> executeNext = true
             }
         } else {
             executeNext = true
@@ -26,7 +25,7 @@ public class StaticFileInterceptor(val folder: String): Interceptor() {
     }
 }
 
-public fun AppServer.serveStaticFilesFromFolder(folder: String) {
-    val staticInterceptor = StaticFileInterceptor(folder)
+public fun AppServer.serveStaticFilesFromFolder(folder: String, useDefaultFile: Boolean = false, defaultFile: String = "index.html") {
+    val staticInterceptor = StaticFileInterceptor(folder, useDefaultFile, defaultFile)
     intercept(staticInterceptor)
 }

--- a/test/main/kotlin/org/wasabi/test/StaticFileInterceptorSpecs.kt
+++ b/test/main/kotlin/org/wasabi/test/StaticFileInterceptorSpecs.kt
@@ -47,4 +47,12 @@ public class StaticFileInterceptorSpecs: TestServerContext() {
         assertEquals("Root", response.body)
     }
 
+    @spec fun requesting_an_existing_static_direcotry_should_serve_when_default_file_is_turn_on() {
+
+        TestServer.appServer.serveStaticFilesFromFolder("testData${File.separatorChar}public", true, "test.html")
+
+        val response = get("http://localhost:${TestServer.definedPort}/", hashMapOf())
+
+        assertEquals("<!DOCTYPE html><head><title></title></head><body>This is an example static file</body></html>", response.body)
+    }
 }


### PR DESCRIPTION
Add switch `useDefaultFile` to `StaticFileInterceptor`. If turn on and request existing directory then return `defaultFile`(configurable).

Default `defaultFile` value is `index.html`
Default `useDefaultFile` value is `false` - no impact to existing solutions.