### PR TITLE
Fixed AutoOptionsInterceptor, now it matches all paths

### DIFF
--- a/src/main/kotlin/org/wasabi/protocol/http/Response.kt
+++ b/src/main/kotlin/org/wasabi/protocol/http/Response.kt
@@ -104,7 +104,7 @@ public class Response() {
     }
 
     public fun setAllowedMethods(allowedMethods: Array<HttpMethod>) {
-        allow = allowedMethods.joinToString(",")
+        addRawHeader("Allow", allowedMethods.map { it.name() }.joinToString(","))
     }
 
     public fun addRawHeader(name: String, value: String) {

--- a/test/main/kotlin/org/wasabi/test/AutoOptionsInterceptorSpecs.kt
+++ b/test/main/kotlin/org/wasabi/test/AutoOptionsInterceptorSpecs.kt
@@ -28,7 +28,10 @@ public class AutoOptionsInterceptorSpecs : TestServerContext() {
         TestServer.appServer.enableAutoOptions()
 
         val response = options("http://localhost:${TestServer.definedPort}/person")
-        assertEquals("GET, POST", response.headers.filter { it.getName() == "Allow"}.first().getValue())
+
+        val allowHeader = response.headers.filter { it.name == "Allow"}.first()
+
+        assertEquals("GET,POST", allowHeader.value)
 
         TestServer.appServer.disableAutoOptions()
     }


### PR DESCRIPTION
previously if route has some params in it or if current request path is complex, then AutoOptionsInterceptor would not work, because until this PR code just compared variables as is, for example: "/customer/{id}" == "/customer/16". 

This PR suggests to use already existing code, PatternAndVerbMatchingRouteLocator to check if route is matching, instead of duplicating that code in several places, and it starts working with more complex routes.