### PR TITLE
Refactor CORSInterceptor to generate allowed methods dynamically

### DIFF
--- a/src/main/kotlin/org/wasabi/interceptors/CORSInterceptor.kt
+++ b/src/main/kotlin/org/wasabi/interceptors/CORSInterceptor.kt
@@ -8,10 +8,13 @@ import org.wasabi.protocol.http.CORSEntry
 import org.wasabi.app.AppServer
 import org.wasabi.protocol.http.StatusCodes
 import org.wasabi.routing.InterceptOn
+import org.wasabi.routing.PatternAndVerbMatchingRouteLocator
 import org.wasabi.routing.Route
 
-public class CORSInterceptor(val routes: ArrayList<Route>, val settings: ArrayList<CORSEntry>): Interceptor() {
+class CORSInterceptor(val routes: ArrayList<Route>, val settings: ArrayList<CORSEntry>): Interceptor() {
     override fun intercept(request: Request, response: Response): Boolean {
+        val routeLocator = PatternAndVerbMatchingRouteLocator(routes)
+
         for (setting in settings) {
             if (setting.path == "*" || request.path.matches(setting.path.toRegex())) {
 
@@ -22,14 +25,15 @@ public class CORSInterceptor(val routes: ArrayList<Route>, val settings: ArrayLi
                 }
                 // This handles the initial OPTIONS request during the CORS transfer.
                 if (request.method == HttpMethod.OPTIONS) {
-                    val methods = routes.filter {
-                        it.path == request.path
-                    }.map {
-                        it.method
-                    }
-                    response.addRawHeader("Allow", methods.joinToString(", "))
-                    response.addRawHeader("Access-Control-Request-Method", setting.methods)
-                    response.addRawHeader("Access-Control-Allow-Origin", setting.path)
+                    val allowedMethods = routes
+                            .filter { routeLocator.compareRouteSegments(it, request.path) }
+                            .map { it.method }
+                            .toTypedArray()
+
+                    response.setAllowedMethods(allowedMethods)
+                    response.addRawHeader("Access-Control-Request-Method", allowedMethods.map { it.name() }.joinToString(","))
+
+                    response.addRawHeader("Access-Control-Allow-Origin", setting.origins)
                     if (setting.headers != "") {
                         response.addRawHeader("Access-Control-Allow-Headers", setting.headers)
                     }
@@ -49,14 +53,14 @@ public class CORSInterceptor(val routes: ArrayList<Route>, val settings: ArrayLi
     }
 }
 
-public fun AppServer.enableCORSGlobally() {
+fun AppServer.enableCORSGlobally() {
     enableCORS(arrayListOf(CORSEntry()))
 }
 
-public fun AppServer.enableCORS(settings: ArrayList<CORSEntry>) {
+fun AppServer.enableCORS(settings: ArrayList<CORSEntry>) {
     intercept(CORSInterceptor(routes, settings), "*", InterceptOn.PostRequest)
 }
 
-public fun AppServer.disableCORS() {
+fun AppServer.disableCORS() {
     this.interceptors.removeAll { it.interceptor is CORSInterceptor }
 }

--- a/test/main/kotlin/org/wasabi/test/CorsSpecs.kt
+++ b/test/main/kotlin/org/wasabi/test/CorsSpecs.kt
@@ -19,14 +19,16 @@ class CorsSpecs : TestServerContext(){
 
     @Test fun cors_should_only_work_on_declared_routes () {
         TestServer.appServer.get("/person", {})
+        TestServer.appServer.post("/person", {})
+
         TestServer.appServer.post("/customer", {})
         TestServer.appServer.enableCORS(arrayListOf(CORSEntry(path = "/person")))
 
         val response = options("http://localhost:${TestServer.definedPort}/person")
-        assertEquals("GET", response.headers.filter { it.getName() == "Allow"}.first().getValue())
-        assertEquals("/person", response.headers.filter { it.getName() == "Access-Control-Allow-Origin"}.first().getValue())
+        assertEquals("GET,POST", response.headers.filter { it.getName() == "Allow"}.first().getValue())
+        assertEquals("*", response.headers.filter { it.getName() == "Access-Control-Allow-Origin"}.first().getValue())
         assertEquals("Origin, X-Requested-With, Content-Type, Accept", response.headers.filter { it.getName() == "Access-Control-Allow-Headers"}.first().getValue())
-        assertEquals("GET, POST, PUT, DELETE", response.headers.filter { it.getName() == "Access-Control-Request-Method"}.first().getValue())
+        assertEquals("GET,POST", response.headers.filter { it.getName() == "Access-Control-Request-Method"}.first().getValue())
 
         val response2 = options("http://localhost:${TestServer.definedPort}/customer")
         assertEquals(405, response2.statusCode)
@@ -36,20 +38,23 @@ class CorsSpecs : TestServerContext(){
 
     @Test fun cors_should_work_on_all_when_globally_enabled () {
         TestServer.appServer.get("/person", {})
+        TestServer.appServer.post("/person", {})
+        TestServer.appServer.put("/person", {})
+
         TestServer.appServer.post("/customer", {})
         TestServer.appServer.enableCORSGlobally()
 
         val response = options("http://localhost:${TestServer.definedPort}/person")
-        assertEquals("GET", response.headers.filter { it.getName() == "Allow"}.first().getValue())
+        assertEquals("GET,POST,PUT", response.headers.filter { it.getName() == "Allow"}.first().getValue())
         assertEquals("*", response.headers.filter { it.getName() == "Access-Control-Allow-Origin"}.first().getValue())
         assertEquals("Origin, X-Requested-With, Content-Type, Accept", response.headers.filter { it.getName() == "Access-Control-Allow-Headers"}.first().getValue())
-        assertEquals("GET, POST, PUT, DELETE", response.headers.filter { it.getName() == "Access-Control-Request-Method"}.first().getValue())
+        assertEquals("GET,POST,PUT", response.headers.filter { it.getName() == "Access-Control-Request-Method"}.first().getValue())
 
         val response2 = options("http://localhost:${TestServer.definedPort}/customer")
         assertEquals("POST", response2.headers.filter { it.getName() == "Allow"}.first().getValue())
         assertEquals("*", response2.headers.filter { it.getName() == "Access-Control-Allow-Origin"}.first().getValue())
         assertEquals("Origin, X-Requested-With, Content-Type, Accept", response2.headers.filter { it.getName() == "Access-Control-Allow-Headers"}.first().getValue())
-        assertEquals("GET, POST, PUT, DELETE", response2.headers.filter { it.getName() == "Access-Control-Request-Method"}.first().getValue())
+        assertEquals("POST", response2.headers.filter { it.getName() == "Access-Control-Request-Method"}.first().getValue())
 
         TestServer.appServer.disableCORS()
     }


### PR DESCRIPTION
Previously CORSInterceptor allowed only GET, POST, PUT, DELETE and these four methods were hardcoded, so they were allowed even if application didn't have routes with these methods defined.

Now interceptor on OPTIONS method returns dynamically detected method list which is allowed.

Also fixed issue with Access-Control-Allow-Origin header, because previously CORSInterceptor assigned setting.path instead of setting.origins .