### PR TITLE
 return customized Allow and Access-Control-Request-Method headers

### DIFF
--- a/src/main/kotlin/org/wasabi/interceptors/CORSInterceptor.kt
+++ b/src/main/kotlin/org/wasabi/interceptors/CORSInterceptor.kt
@@ -37,7 +37,7 @@ class CORSInterceptor(val routes: ArrayList<Route>, val settings: ArrayList<CORS
                         availableMethods.intersect(setting.methods)
                     }
 
-                    response.addRawHeader("Access-Control-Request-Method", allowedMethods.map { it.name() }.joinToString(","))
+                    response.addRawHeader("Access-Control-Allow-Methods", allowedMethods.map { it.name() }.joinToString(","))
 
                     response.addRawHeader("Access-Control-Allow-Origin", setting.origins)
                     if (setting.headers != "") {

--- a/src/main/kotlin/org/wasabi/interceptors/CORSInterceptor.kt
+++ b/src/main/kotlin/org/wasabi/interceptors/CORSInterceptor.kt
@@ -23,14 +23,21 @@ class CORSInterceptor(val routes: ArrayList<Route>, val settings: ArrayList<CORS
                 if (response.statusCode == StatusCodes.OK.code) {
                     response.addRawHeader("Access-Control-Allow-Origin", setting.path)
                 }
+
                 // This handles the initial OPTIONS request during the CORS transfer.
                 if (request.method == HttpMethod.OPTIONS) {
-                    val allowedMethods = routes
+                    val availableMethods = routes
                             .filter { routeLocator.compareRouteSegments(it, request.path) }
                             .map { it.method }
-                            .toTypedArray()
+                            .toSet()
 
-                    response.setAllowedMethods(allowedMethods)
+                    val allowedMethods = if (setting.methods == CORSEntry.ALL_AVAILABLE_METHODS) {
+                        availableMethods
+                    } else {
+                        availableMethods.intersect(setting.methods)
+                    }
+
+                    response.setAllowedMethods(allowedMethods.toTypedArray())
                     response.addRawHeader("Access-Control-Request-Method", allowedMethods.map { it.name() }.joinToString(","))
 
                     response.addRawHeader("Access-Control-Allow-Origin", setting.origins)

--- a/src/main/kotlin/org/wasabi/interceptors/CORSInterceptor.kt
+++ b/src/main/kotlin/org/wasabi/interceptors/CORSInterceptor.kt
@@ -37,7 +37,6 @@ class CORSInterceptor(val routes: ArrayList<Route>, val settings: ArrayList<CORS
                         availableMethods.intersect(setting.methods)
                     }
 
-                    response.setAllowedMethods(allowedMethods.toTypedArray())
                     response.addRawHeader("Access-Control-Request-Method", allowedMethods.map { it.name() }.joinToString(","))
 
                     response.addRawHeader("Access-Control-Allow-Origin", setting.origins)

--- a/src/main/kotlin/org/wasabi/protocol/http/CORSEntry.kt
+++ b/src/main/kotlin/org/wasabi/protocol/http/CORSEntry.kt
@@ -1,12 +1,17 @@
 package org.wasabi.protocol.http
 
-import java.util.ArrayList
+import io.netty.handler.codec.http.HttpMethod
 
 public class CORSEntry(val path: String = "*",
                        val origins: String = "*",
-                       val methods: String = "GET, POST, PUT, DELETE",
+                       val methods: Set<HttpMethod>? = CORSEntry.ALL_AVAILABLE_METHODS,
                        val headers: String = "Origin, X-Requested-With, Content-Type, Accept",
                        val credentials: String = "",
                        val preflightMaxAge: String = "") {
+
+        companion object {
+            val NO_METHODS = emptySet<HttpMethod>()
+            val ALL_AVAILABLE_METHODS = null
+        }
 
 }

--- a/test/main/kotlin/org/wasabi/test/CorsSpecs.kt
+++ b/test/main/kotlin/org/wasabi/test/CorsSpecs.kt
@@ -12,10 +12,6 @@ fun getHeader(headerName: String, response: HttpClientResponse): String? {
             .firstOrNull()?.value
 }
 
-fun getAllowHeader(response: HttpClientResponse): String? {
-    return getHeader("Allow", response)
-}
-
 fun getCORSAllowHeader(response: HttpClientResponse): String? {
     return getHeader("Access-Control-Request-Method", response)
 }
@@ -40,7 +36,6 @@ class CorsSpecs : TestServerContext(){
         TestServer.appServer.enableCORS(arrayListOf(CORSEntry(path = "/person")))
 
         val response = options("http://localhost:${TestServer.definedPort}/person")
-        assertEquals("GET,POST", response.headers.filter { it.getName() == "Allow"}.first().getValue())
         assertEquals("*", response.headers.filter { it.getName() == "Access-Control-Allow-Origin"}.first().getValue())
         assertEquals("Origin, X-Requested-With, Content-Type, Accept", response.headers.filter { it.getName() == "Access-Control-Allow-Headers"}.first().getValue())
         assertEquals("GET,POST", response.headers.filter { it.getName() == "Access-Control-Request-Method"}.first().getValue())
@@ -60,13 +55,11 @@ class CorsSpecs : TestServerContext(){
         TestServer.appServer.enableCORSGlobally()
 
         val response = options("http://localhost:${TestServer.definedPort}/person")
-        assertEquals("GET,POST,PUT", response.headers.filter { it.getName() == "Allow"}.first().getValue())
         assertEquals("*", response.headers.filter { it.getName() == "Access-Control-Allow-Origin"}.first().getValue())
         assertEquals("Origin, X-Requested-With, Content-Type, Accept", response.headers.filter { it.getName() == "Access-Control-Allow-Headers"}.first().getValue())
         assertEquals("GET,POST,PUT", response.headers.filter { it.getName() == "Access-Control-Request-Method"}.first().getValue())
 
         val response2 = options("http://localhost:${TestServer.definedPort}/customer")
-        assertEquals("POST", response2.headers.filter { it.getName() == "Allow"}.first().getValue())
         assertEquals("*", response2.headers.filter { it.getName() == "Access-Control-Allow-Origin"}.first().getValue())
         assertEquals("Origin, X-Requested-With, Content-Type, Accept", response2.headers.filter { it.getName() == "Access-Control-Allow-Headers"}.first().getValue())
         assertEquals("POST", response2.headers.filter { it.getName() == "Access-Control-Request-Method"}.first().getValue())
@@ -103,7 +96,6 @@ class CorsSpecs : TestServerContext(){
         TestServer.appServer.enableCORSGlobally()
 
         val response = options("http://localhost:${TestServer.definedPort}/person")
-        assertEquals("GET,POST,PATCH,HEAD", getAllowHeader(response))
         assertEquals("GET,POST,PATCH,HEAD", getCORSAllowHeader(response))
 
         TestServer.appServer.disableCORS()
@@ -133,19 +125,15 @@ class CorsSpecs : TestServerContext(){
         )
 
         val personResponse = options("http://localhost:${TestServer.definedPort}/person")
-        assertEquals("GET,POST,PATCH", getAllowHeader(personResponse))
         assertEquals("GET,POST,PATCH", getCORSAllowHeader(personResponse))
 
         val personalizationResponse = options("http://localhost:${TestServer.definedPort}/personalization")
-        assertEquals("GET", getAllowHeader(personalizationResponse))
         assertEquals("GET", getCORSAllowHeader(personalizationResponse))
 
         val accountResponse = options("http://localhost:${TestServer.definedPort}/account")
-        assertEquals("GET,POST", getAllowHeader(accountResponse))
         assertEquals("GET,POST", getCORSAllowHeader(accountResponse))
 
         val threadResponse = options("http://localhost:${TestServer.definedPort}/thread")
-        assertEquals(null, getAllowHeader(threadResponse))
         assertEquals(null, getCORSAllowHeader(threadResponse))
 
         TestServer.appServer.disableCORS()

--- a/test/main/kotlin/org/wasabi/test/CorsSpecs.kt
+++ b/test/main/kotlin/org/wasabi/test/CorsSpecs.kt
@@ -13,7 +13,7 @@ fun getHeader(headerName: String, response: HttpClientResponse): String? {
 }
 
 fun getCORSAllowHeader(response: HttpClientResponse): String? {
-    return getHeader("Access-Control-Request-Method", response)
+    return getHeader("Access-Control-Allow-Methods", response)
 }
 
 class CorsSpecs : TestServerContext(){
@@ -38,7 +38,7 @@ class CorsSpecs : TestServerContext(){
         val response = options("http://localhost:${TestServer.definedPort}/person")
         assertEquals("*", response.headers.filter { it.getName() == "Access-Control-Allow-Origin"}.first().getValue())
         assertEquals("Origin, X-Requested-With, Content-Type, Accept", response.headers.filter { it.getName() == "Access-Control-Allow-Headers"}.first().getValue())
-        assertEquals("GET,POST", response.headers.filter { it.getName() == "Access-Control-Request-Method"}.first().getValue())
+        assertEquals("GET,POST", getCORSAllowHeader(response))
 
         val response2 = options("http://localhost:${TestServer.definedPort}/customer")
         assertEquals(405, response2.statusCode)
@@ -57,12 +57,12 @@ class CorsSpecs : TestServerContext(){
         val response = options("http://localhost:${TestServer.definedPort}/person")
         assertEquals("*", response.headers.filter { it.getName() == "Access-Control-Allow-Origin"}.first().getValue())
         assertEquals("Origin, X-Requested-With, Content-Type, Accept", response.headers.filter { it.getName() == "Access-Control-Allow-Headers"}.first().getValue())
-        assertEquals("GET,POST,PUT", response.headers.filter { it.getName() == "Access-Control-Request-Method"}.first().getValue())
+        assertEquals("GET,POST,PUT", getCORSAllowHeader(response))
 
         val response2 = options("http://localhost:${TestServer.definedPort}/customer")
         assertEquals("*", response2.headers.filter { it.getName() == "Access-Control-Allow-Origin"}.first().getValue())
         assertEquals("Origin, X-Requested-With, Content-Type, Accept", response2.headers.filter { it.getName() == "Access-Control-Allow-Headers"}.first().getValue())
-        assertEquals("POST", response2.headers.filter { it.getName() == "Access-Control-Request-Method"}.first().getValue())
+        assertEquals("POST", getCORSAllowHeader(response2))
 
         TestServer.appServer.disableCORS()
     }


### PR DESCRIPTION
WARNING! This commit contains changes in CORSEntry class which breaks backwards compatibility!
 This commit adds ability to configure application server to return custom collection of allowed methods (in Allow and Access-Control-Request-Method headers) based on configuration provided with CORSEntry classes.