### PR TITLE
moved post execution post processors to the end of any request processing

### DIFF
--- a/src/main/kotlin/org/wasabi/protocol/http/HttpRequestHandler.kt
+++ b/src/main/kotlin/org/wasabi/protocol/http/HttpRequestHandler.kt
@@ -81,10 +81,6 @@ public class HttpRequestHandler(private val appServer: AppServer){
 
                         // process the route specific post execution interceptors
                         runInterceptors(postExecutionInterceptors, routeHandlers)
-
-                        // Run global interceptors again
-                        runInterceptors(postExecutionInterceptors)
-
                     }
 
                 } catch (e: InvalidMethodException)  {
@@ -103,8 +99,13 @@ public class HttpRequestHandler(private val appServer: AppServer){
                     } catch (exception: ExceptionHandlerNotFoundException) {
                         response.setStatus(StatusCodes.InternalServerError)
                     }
+                } finally {
+                    if (!bypassPipeline) {
+                        // Run global interceptors again
+                        runInterceptors(postExecutionInterceptors)
+                    }
+                    writeResponse(ctx!!, response)
                 }
-                writeResponse(ctx!!, response)
             }
         }
     }


### PR DESCRIPTION
In order to handle exception content negotiation.
See test for example.